### PR TITLE
getGameDir()方法有错误

### DIFF
--- a/src/main/java/cn/tealc/wutheringwavestool/util/GameResourcesManager.java
+++ b/src/main/java/cn/tealc/wutheringwavestool/util/GameResourcesManager.java
@@ -21,11 +21,14 @@ public class GameResourcesManager {
     private static final Logger LOG = LoggerFactory.getLogger(GameResourcesManager.class);
 
     public static File getGameDir(){
-        File dir = new File(Config.setting.getGameRootDir());
-        if (!dir.exists()) {
-            return null;
+        if (Config.setting.getGameRootDir() != null) {
+            File dir = new File(Config.setting.getGameRootDir());
+            if (!dir.exists()) {
+                return null;
+            }
+            return dir;
         }
-        return dir;
+        return null;
     }
 
     public static File getGameDB(){


### PR DESCRIPTION
当程序首次启动且 setting.json 未创建时，Config.setting.getGameRootDir() 返回 null，而new File()的参数为null时会抛出错误，导致无法触发 "ui.home.message.type04" 消息。为了解决这个问题，我们需要在获取游戏根目录之前检查返回值是否为 null，并在必要时触发消息。