### PR TITLE
refactor: 用 Java Sobel 边缘检测替换 JS Canvas 像素比对的极验缺口识别

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,11 @@
             <version>${javafx.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-web</artifactId>
+            <version>${javafx.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.kordamp.ikonli</groupId>
             <artifactId>ikonli-javafx</artifactId>
             <version>${ikonli.version}</version>

--- a/src/main/java/cn/tealc/wutheringwavestool/ui/kujiequ/account/AccountUpdateView.java
+++ b/src/main/java/cn/tealc/wutheringwavestool/ui/kujiequ/account/AccountUpdateView.java
@@ -145,8 +145,7 @@ public class AccountUpdateView extends BaseDialog implements FxmlView<AccountUpd
 
     @FXML
     void sendLoginCode(ActionEvent event) {
-       // viewModel.sendSMS(this::showSmsFailDialog);
-        showSmsFailDialog();
+        viewModel.sendSMS(this::showSmsFailDialog);
     }
 
     private void showSmsFailDialog() {

--- a/src/main/java/cn/tealc/wutheringwavestool/ui/kujiequ/account/AccountUpdateView.java
+++ b/src/main/java/cn/tealc/wutheringwavestool/ui/kujiequ/account/AccountUpdateView.java
@@ -25,6 +25,10 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
+
+import javafx.scene.Node;
+import javafx.stage.Window;
 
 public class AccountUpdateView extends BaseDialog implements FxmlView<AccountUpdateViewModel> {
     private static final Logger log = LoggerFactory.getLogger(AccountUpdateView.class);
@@ -145,7 +149,20 @@ public class AccountUpdateView extends BaseDialog implements FxmlView<AccountUpd
 
     @FXML
     void sendLoginCode(ActionEvent event) {
-        viewModel.sendSMS(this::showSmsFailDialog);
+        Window owner = ((Node) event.getSource()).getScene().getWindow();
+        viewModel.sendSMS(smsData -> {
+            GeetestCaptchaDialog dialog = new GeetestCaptchaDialog(
+                owner,
+                smsData.getGt(),
+                smsData.getChallenge(),
+                geeTestJson -> {
+                    if (geeTestJson != null && !geeTestJson.isEmpty()) {
+                        viewModel.sendSMS(ignored -> {}, geeTestJson);
+                    }
+                }
+            );
+            dialog.show();
+        });
     }
 
     private void showSmsFailDialog() {

--- a/src/main/java/cn/tealc/wutheringwavestool/ui/kujiequ/account/AccountUpdateViewModel.java
+++ b/src/main/java/cn/tealc/wutheringwavestool/ui/kujiequ/account/AccountUpdateViewModel.java
@@ -16,6 +16,7 @@ import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 public class AccountUpdateViewModel extends BaseViewModel {
     public static final String EVENT_CLOSE = "EVENT_CLOSE";
@@ -93,9 +94,9 @@ public class AccountUpdateViewModel extends BaseViewModel {
     /**
      * 发送短信验证码（首次尝试，不带极验数据）
      *
-     * @param onCaptchaRequired 当需要极验人机验证时回调
+     * @param onCaptchaRequired 当需要极验人机验证时回调，参数为极验数据
      */
-    public void sendSMS(Runnable onCaptchaRequired) {
+    public void sendSMS(Consumer<SmsCodeResponse> onCaptchaRequired) {
         sendSMS(onCaptchaRequired, "");
     }
 
@@ -103,10 +104,10 @@ public class AccountUpdateViewModel extends BaseViewModel {
     /**
      * 发送短信验证码（带极验数据重试）
      *
-     * @param onCaptchaRequired 当需要极验人机验证时回调
+     * @param onCaptchaRequired 当需要极验人机验证时回调，参数为极验数据
      * @param geeTestData       极验验证通过后的 tokens JSON，首次传入空串
      */
-    public void sendSMS(Runnable onCaptchaRequired, String geeTestData) {
+    public void sendSMS(Consumer<SmsCodeResponse> onCaptchaRequired, String geeTestData) {
         SendSmsTask task = new SendSmsTask(getPhone(), geeTestData);
         task.setOnSucceeded(event -> {
             ResponseBody<SmsCodeResponse> value = task.getValue();
@@ -116,8 +117,10 @@ public class AccountUpdateViewModel extends BaseViewModel {
                 SmsCodeResponse smsData = value.getData();
                 if (smsData != null) {
                     NotificationManager.message(MessageInfo.warning("需要完成人机验证"));
+                    onCaptchaRequired.accept(smsData);
+                } else {
+                    NotificationManager.message(MessageInfo.warning("需要人机验证，但缺少验证参数"));
                 }
-                onCaptchaRequired.run();
             } else {
                 NotificationManager.message(MessageInfo.warning(value.getMsg()));
             }

--- a/src/main/java/cn/tealc/wutheringwavestool/ui/kujiequ/account/AccountUpdateViewModel.java
+++ b/src/main/java/cn/tealc/wutheringwavestool/ui/kujiequ/account/AccountUpdateViewModel.java
@@ -8,6 +8,7 @@ import cn.tealc.wutheringwavestool.service.UserInfoService;
 import cn.tealc.wutheringwavestool.ui.base.BaseViewModel;
 import com.google.inject.Inject;
 import com.kuro.kujiequ.model.sign.UserInfo;
+import com.kuro.kujiequ.model.sms.SmsCodeResponse;
 import com.kuro.kujiequ.thread.base.user.LoginUserTask;
 import com.kuro.kujiequ.thread.rolebox.role.GameRoleSeekTask;
 import com.kuro.kujiequ.thread.sms.SendSmsTask;
@@ -89,14 +90,34 @@ public class AccountUpdateViewModel extends BaseViewModel {
         Thread.startVirtualThread(task);
     }
 
-    public void sendSMS(Runnable callback) {
-        SendSmsTask task = new SendSmsTask(getPhone());
+    /**
+     * 发送短信验证码（首次尝试，不带极验数据）
+     *
+     * @param onCaptchaRequired 当需要极验人机验证时回调
+     */
+    public void sendSMS(Runnable onCaptchaRequired) {
+        sendSMS(onCaptchaRequired, "");
+    }
+
+
+    /**
+     * 发送短信验证码（带极验数据重试）
+     *
+     * @param onCaptchaRequired 当需要极验人机验证时回调
+     * @param geeTestData       极验验证通过后的 tokens JSON，首次传入空串
+     */
+    public void sendSMS(Runnable onCaptchaRequired, String geeTestData) {
+        SendSmsTask task = new SendSmsTask(getPhone(), geeTestData);
         task.setOnSucceeded(event -> {
-            ResponseBody<Boolean> value = task.getValue();
+            ResponseBody<SmsCodeResponse> value = task.getValue();
             if (value.getCode() == 200) {
                 NotificationManager.message(MessageInfo.success("验证码发送成功"));
             } else if (value.getCode() == 41000) {
-                callback.run();
+                SmsCodeResponse smsData = value.getData();
+                if (smsData != null) {
+                    NotificationManager.message(MessageInfo.warning("需要完成人机验证"));
+                }
+                onCaptchaRequired.run();
             } else {
                 NotificationManager.message(MessageInfo.warning(value.getMsg()));
             }

--- a/src/main/java/cn/tealc/wutheringwavestool/ui/kujiequ/account/GapDetector.java
+++ b/src/main/java/cn/tealc/wutheringwavestool/ui/kujiequ/account/GapDetector.java
@@ -1,0 +1,277 @@
+package cn.tealc.wutheringwavestool.ui.kujiequ.account;
+
+import javax.imageio.ImageIO;
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.util.Base64;
+
+/**
+ * Pure-Java GeeTest V3 slide captcha gap detector.
+ * <p>
+ * Uses Sobel edge detection + template matching to locate the puzzle gap,
+ * inspired by COOLasHEL/geetest-v3-solver (OpenCV) but with zero native deps.
+ * Designed to replace the low-accuracy JS canvas pixel-diff approach.
+ * </p>
+ * <p>
+ * Algorithm:
+ * <ol>
+ *   <li>Extract puzzle piece bounding box from slice image alpha channel</li>
+ *   <li>Sobel edge detection on piece and background</li>
+ *   <li>Zero out left-side edges (piece overlay area) from bg to avoid self-match</li>
+ *   <li>Slide piece edges across bg edges, find best SAD (sum of absolute differences)</li>
+ *   <li>Adjust for piece starting offset</li>
+ * </ol>
+ * </p>
+ */
+public class GapDetector {
+
+    /**
+     * Detect the horizontal gap position for a GeeTest V3 slide captcha.
+     *
+     * @param bgBase64    base64-encoded PNG of the background canvas (geetest_canvas_bg)
+     * @param sliceBase64 base64-encoded PNG of the slice canvas (geetest_canvas_slice)
+     * @return gap X position in pixels, or -1 if detection failed
+     */
+    public static int detect(String bgBase64, String sliceBase64) {
+        BufferedImage bg = decodeBase64(bgBase64);
+        BufferedImage slice = decodeBase64(sliceBase64);
+        if (bg == null || slice == null) return -1;
+
+        // 1. Get piece bounding box from alpha channel
+        Rectangle pieceBounds = getPieceBounds(slice);
+        if (pieceBounds == null || pieceBounds.width < 5 || pieceBounds.height < 5) {
+            return -1;
+        }
+
+        // 2. Crop piece
+        BufferedImage piece;
+        try {
+            piece = slice.getSubimage(pieceBounds.x, pieceBounds.y,
+                    pieceBounds.width, pieceBounds.height);
+        } catch (Exception e) {
+            return -1;
+        }
+
+        // 3. Edge detection
+        BufferedImage pieceEdges = sobelEdges(toGrayscale(piece));
+        BufferedImage bgEdges = sobelEdges(toGrayscale(bg));
+
+        // 4. Zero out edges where the piece overlay sits (left side),
+        //    so we don't accidentally match the piece against itself
+        int searchStart = Math.min(pieceBounds.x + pieceBounds.width + 5, bgEdges.getWidth() - 1);
+        clearEdges(bgEdges, 0, searchStart);
+
+        // 5. Template matching: find where piece edges best align with bg edges
+        int matchX = matchTemplate(bgEdges, pieceEdges);
+        if (matchX < 0) return -1;
+
+        // 6. Final gap position = match position - piece starting offset
+        //    The piece on the slice canvas starts at pieceBounds.x.
+        //    So the actual drag distance is from the piece's current position
+        //    to the matched gap position.
+        int gapX = matchX - pieceBounds.x;
+        if (gapX < 0) gapX = matchX;
+
+        return gapX;
+    }
+
+
+    // ========================================================================
+    // Image decode
+    // ========================================================================
+
+    private static BufferedImage decodeBase64(String dataUrl) {
+        if (dataUrl == null || dataUrl.isEmpty()) return null;
+        try {
+            // Strip data:image/png;base64, prefix if present
+            String base64 = dataUrl;
+            int comma = dataUrl.indexOf(',');
+            if (comma >= 0) {
+                base64 = dataUrl.substring(comma + 1);
+            }
+            byte[] bytes = Base64.getDecoder().decode(base64);
+            return ImageIO.read(new ByteArrayInputStream(bytes));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+
+    // ========================================================================
+    // Grayscale
+    // ========================================================================
+
+    private static BufferedImage toGrayscale(BufferedImage img) {
+        int w = img.getWidth();
+        int h = img.getHeight();
+        BufferedImage gray = new BufferedImage(w, h, BufferedImage.TYPE_BYTE_GRAY);
+        for (int y = 0; y < h; y++) {
+            for (int x = 0; x < w; x++) {
+                int rgb = img.getRGB(x, y);
+                int r = (rgb >> 16) & 0xFF;
+                int g = (rgb >> 8) & 0xFF;
+                int b = rgb & 0xFF;
+                int luma = (int) (0.299 * r + 0.587 * g + 0.114 * b);
+                gray.setRGB(x, y, (luma << 16) | (luma << 8) | luma);
+            }
+        }
+        return gray;
+    }
+
+
+    // ========================================================================
+    // Sobel edge detection
+    // ========================================================================
+
+    private static BufferedImage sobelEdges(BufferedImage gray) {
+        int w = gray.getWidth();
+        int h = gray.getHeight();
+        BufferedImage edges = new BufferedImage(w, h, BufferedImage.TYPE_BYTE_GRAY);
+
+        // Build luminance array
+        int[][] lum = new int[w][h];
+        for (int y = 0; y < h; y++) {
+            for (int x = 0; x < w; x++) {
+                lum[x][y] = gray.getRGB(x, y) & 0xFF;
+            }
+        }
+
+        // Sobel operator (3x3)
+        for (int y = 1; y < h - 1; y++) {
+            for (int x = 1; x < w - 1; x++) {
+                int gx = -lum[x - 1][y - 1] + lum[x + 1][y - 1]
+                         - 2 * lum[x - 1][y] + 2 * lum[x + 1][y]
+                         - lum[x - 1][y + 1] + lum[x + 1][y + 1];
+
+                int gy = -lum[x - 1][y - 1] - 2 * lum[x][y - 1] - lum[x + 1][y - 1]
+                         + lum[x - 1][y + 1] + 2 * lum[x][y + 1] + lum[x + 1][y + 1];
+
+                int mag = (int) Math.sqrt(gx * gx + gy * gy);
+                if (mag > 255) mag = 255;
+                edges.setRGB(x, y, (mag << 16) | (mag << 8) | mag);
+            }
+        }
+        return edges;
+    }
+
+
+    // ========================================================================
+    // Piece bounding box from alpha channel
+    // ========================================================================
+
+    private static Rectangle getPieceBounds(BufferedImage slice) {
+        int w = slice.getWidth();
+        int h = slice.getHeight();
+        int minX = w, maxX = 0, minY = h, maxY = 0;
+        boolean found = false;
+
+        // Check if slice has alpha by looking at type
+        boolean hasAlpha = slice.getColorModel().hasAlpha();
+
+        for (int y = 0; y < h; y++) {
+            for (int x = 0; x < w; x++) {
+                int rgba = slice.getRGB(x, y);
+                int alpha;
+                if (hasAlpha) {
+                    alpha = (rgba >> 24) & 0xFF;
+                } else {
+                    // No alpha: treat dark pixels as transparent
+                    int r = (rgba >> 16) & 0xFF;
+                    int g = (rgba >> 8) & 0xFF;
+                    int b = rgba & 0xFF;
+                    alpha = (r < 10 && g < 10 && b < 10) ? 0 : 255;
+                }
+                if (alpha > 20) {
+                    if (x < minX) minX = x;
+                    if (x > maxX) maxX = x;
+                    if (y < minY) minY = y;
+                    if (y > maxY) maxY = y;
+                    found = true;
+                }
+            }
+        }
+
+        if (!found) return null;
+        return new Rectangle(minX, minY, maxX - minX + 1, maxY - minY + 1);
+    }
+
+
+    // ========================================================================
+    // Edge clearing
+    // ========================================================================
+
+    private static void clearEdges(BufferedImage edges, int fromX, int toX) {
+        int h = edges.getHeight();
+        for (int y = 0; y < h; y++) {
+            for (int x = fromX; x < toX && x < edges.getWidth(); x++) {
+                edges.setRGB(x, y, 0); // black = no edge
+            }
+        }
+    }
+
+
+    // ========================================================================
+    // Template matching (Sum of Absolute Differences on edge images)
+    // ========================================================================
+
+    private static int matchTemplate(BufferedImage bgEdges, BufferedImage pieceEdges) {
+        int bw = bgEdges.getWidth();
+        int bh = bgEdges.getHeight();
+        int pw = pieceEdges.getWidth();
+        int ph = pieceEdges.getHeight();
+
+        if (pw >= bw || ph >= bh) return -1;
+
+        int maxX = bw - pw;
+        int bestX = -1;
+        double bestScore = Double.MAX_VALUE;
+
+        // Precompute edge strength for each pixel (0-255)
+        int[][] bgVals = new int[bw][bh];
+        for (int y = 0; y < bh; y++) {
+            for (int x = 0; x < bw; x++) {
+                bgVals[x][y] = bgEdges.getRGB(x, y) & 0xFF;
+            }
+        }
+
+        int[][] pVals = new int[pw][ph];
+        int edgePixelCount = 0;
+        for (int y = 0; y < ph; y++) {
+            for (int x = 0; x < pw; x++) {
+                int v = pieceEdges.getRGB(x, y) & 0xFF;
+                pVals[x][y] = v;
+                if (v > 30) edgePixelCount++; // count non-trivial edge pixels
+            }
+        }
+
+        if (edgePixelCount < 10) return -1; // piece has no edges
+
+        // Slide across bg, compute SAD
+        for (int x = 0; x <= maxX; x++) {
+            double score = 0;
+            int count = 0;
+
+            for (int py = 0; py < ph; py++) {
+                for (int px = 0; px < pw; px++) {
+                    int pv = pVals[px][py];
+                    if (pv < 30) continue; // skip non-edge pixels
+
+                    int bv = bgVals[x + px][py];
+                    score += Math.abs(pv - bv);
+                    count++;
+                }
+            }
+
+            if (count > 0) {
+                double avg = score / count;
+                if (avg < bestScore) {
+                    bestScore = avg;
+                    bestX = x;
+                }
+            }
+        }
+
+        return bestX;
+    }
+}

--- a/src/main/java/cn/tealc/wutheringwavestool/ui/kujiequ/account/GeetestCaptchaDialog.java
+++ b/src/main/java/cn/tealc/wutheringwavestool/ui/kujiequ/account/GeetestCaptchaDialog.java
@@ -24,12 +24,13 @@ public class GeetestCaptchaDialog {
 
     private final Stage stage;
     private final Consumer<String> onSolved;
+    private final WebEngine engine;
 
     public GeetestCaptchaDialog(Window owner, String gt, String challenge, Consumer<String> onSolved) {
         this.onSolved = onSolved;
 
         WebView webView = new WebView();
-        WebEngine engine = webView.getEngine();
+        this.engine = webView.getEngine();
 
         // Set up JS bridge after page loads
         engine.getLoadWorker().stateProperty().addListener((obs, old, state) -> {
@@ -78,6 +79,32 @@ public class GeetestCaptchaDialog {
                 onSolved.accept(json);
                 stage.close();
             });
+        }
+
+        /**
+         * Called from JS to detect the slide gap position using Java-side
+         * image processing (Sobel edge detection + template matching).
+         * Runs asynchronously: spawns a background thread so the JavaFX
+         * WebView thread is not blocked. Results are delivered via
+         * {@code window.onGapDetected(gapX)} in JS.
+         *
+         * @param bgBase64    base64 data URL of .geetest_canvas_bg
+         * @param sliceBase64 base64 data URL of .geetest_canvas_slice
+         */
+        public void detectGap(String bgBase64, String sliceBase64) {
+            new Thread(() -> {
+                try {
+                    int gapX = GapDetector.detect(bgBase64, sliceBase64);
+                    int finalGapX = Math.max(gapX, -1);
+                    Platform.runLater(() ->
+                        engine.executeScript("window.onGapDetected(" + finalGapX + ")")
+                    );
+                } catch (Exception e) {
+                    Platform.runLater(() ->
+                        engine.executeScript("window.onGapDetected(-1)")
+                    );
+                }
+            }).start();
         }
     }
 }

--- a/src/main/java/cn/tealc/wutheringwavestool/ui/kujiequ/account/GeetestCaptchaDialog.java
+++ b/src/main/java/cn/tealc/wutheringwavestool/ui/kujiequ/account/GeetestCaptchaDialog.java
@@ -1,0 +1,83 @@
+package cn.tealc.wutheringwavestool.ui.kujiequ.account;
+
+import cn.tealc.wutheringwavestool.FXResourcesLoader;
+import javafx.application.Platform;
+import javafx.concurrent.Worker;
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.scene.web.WebEngine;
+import javafx.scene.web.WebView;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+import javafx.stage.Window;
+import netscape.javascript.JSObject;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+public class GeetestCaptchaDialog {
+    private static final String HTML_PATH = "/cn/tealc/wutheringwavestool/ui/geetest.html";
+
+    private final Stage stage;
+    private final Consumer<String> onSolved;
+
+    public GeetestCaptchaDialog(Window owner, String gt, String challenge, Consumer<String> onSolved) {
+        this.onSolved = onSolved;
+
+        WebView webView = new WebView();
+        WebEngine engine = webView.getEngine();
+
+        // Set up JS bridge after page loads
+        engine.getLoadWorker().stateProperty().addListener((obs, old, state) -> {
+            if (state == Worker.State.SUCCEEDED) {
+                JSObject window = (JSObject) engine.executeScript("window");
+                window.setMember("bridge", new CaptchaBridge());
+            }
+        });
+
+        // Load HTML with injected parameters
+        String html = loadHtml(gt, challenge);
+        engine.loadContent(html);
+
+        // Stage setup
+        StackPane root = new StackPane(webView);
+        Scene scene = new Scene(root, 400, 500);
+
+        stage = new Stage();
+        stage.initOwner(owner);
+        stage.initModality(Modality.WINDOW_MODAL);
+        stage.setTitle("人机验证");
+        stage.setScene(scene);
+        stage.setResizable(false);
+        stage.setOnCloseRequest(e -> onSolved.accept(""));
+    }
+
+    public void show() {
+        stage.showAndWait();
+    }
+
+    private String loadHtml(String gt, String challenge) {
+        try (InputStream is = FXResourcesLoader.loadStream(HTML_PATH);
+             BufferedReader br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
+            String content = br.lines().collect(Collectors.joining("\n"));
+            return content.replace("${gt}", gt != null ? gt : "")
+                          .replace("${challenge}", challenge != null ? challenge : "");
+        } catch (Exception e) {
+            return "<html><body><h1>Failed to load captcha</h1></body></html>";
+        }
+    }
+
+    // JS bridge - must be public for JSObject access
+    public class CaptchaBridge {
+        public void onCaptchaSolved(String json) {
+            Platform.runLater(() -> {
+                onSolved.accept(json);
+                stage.close();
+            });
+        }
+    }
+}

--- a/src/main/java/com/kuro/kujiequ/model/sms/SmsCodeResponse.java
+++ b/src/main/java/com/kuro/kujiequ/model/sms/SmsCodeResponse.java
@@ -1,0 +1,42 @@
+package com.kuro.kujiequ.model.sms;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * APP 端 getSmsCode API 响应中 data 字段的模型。
+ * 当 geeTest=true 时，需要用户完成极验人机验证，
+ * 此时 gt 和 challenge 用于初始化极验 SDK。
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SmsCodeResponse {
+    private boolean geeTest;
+    private String gt;
+    private String challenge;
+
+    public SmsCodeResponse() {
+    }
+
+    public boolean isGeeTest() {
+        return geeTest;
+    }
+
+    public void setGeeTest(boolean geeTest) {
+        this.geeTest = geeTest;
+    }
+
+    public String getGt() {
+        return gt;
+    }
+
+    public void setGt(String gt) {
+        this.gt = gt;
+    }
+
+    public String getChallenge() {
+        return challenge;
+    }
+
+    public void setChallenge(String challenge) {
+        this.challenge = challenge;
+    }
+}

--- a/src/main/java/com/kuro/kujiequ/thread/sms/SendSmsTask.java
+++ b/src/main/java/com/kuro/kujiequ/thread/sms/SendSmsTask.java
@@ -1,152 +1,151 @@
 package com.kuro.kujiequ.thread.sms;
 
+import cn.tealc.wutheringwavestool.base.AppInjector;
 import cn.tealc.wutheringwavestool.model.ResponseBody;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import javafx.concurrent.Task;
+import com.kuro.kujiequ.model.sms.SmsCodeResponse;
+import com.kuro.kujiequ.thread.BaseTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.UUID;
 
 /**
- * 发送验证码
- *
- * @author leck
- * @date 2026/05/30
+ * 发送验证码 — APP 端 API
+ * <p>
+ * 调用 api.kurobbs.com/user/getSmsCode 发送短信验证码。
+ * 当触发风控时，API 返回 geeTest=true，需要用户完成极验人机验证后重试。
  */
-public class SendSmsTask extends Task<ResponseBody<Boolean>> {
-    private static final HttpClient CLIENT = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(10))
-            .followRedirects(HttpClient.Redirect.NORMAL)
-            .build();
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+public class SendSmsTask extends BaseTask<ResponseBody<SmsCodeResponse>> {
     private static final Logger LOG = LoggerFactory.getLogger(SendSmsTask.class);
-    private static final String GET_SMS_CODE_URL = "https://sdkapi.kurogame.com/sdkcom/v2/login/getPhoneCode.lg";
-    private static final String REFERER = "https://usercenter.kurogames.com/";
-    private static final String ORIGIN = "https://usercenter.kurogames.com";
-    private static final String USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36 Edg/143.0.0.0";
-    private static final String SEC_CH_UA = "\"Microsoft Edge\";v=\"143\", \"Chromium\";v=\"143\", \"Not A(Brand\";v=\"24\"";
-    private static final String E_PARAM = "1";
-    private static final String REDIRECT_URI = "1";
-    private static final String PACK_MARK = "1";
-    private static final String PROJECT_ID = "G152";
-    private static final String PRODUCT_ID = "A1493";
-    private static final String PLATFORM = "h5";
-    private static final String CHANNEL_ID = "211";
-    private static final String VERSION = "2.1.2";
-    private static final String SDK_VERSION = "2.1.2";
-    private static final String RESPONSE_TYPE = "code";
-    private static final String PKG = "com.kurogame.mingchao";
-    private static final String CLIENT_ID = "vvkewnskrxxwfo0yi61cy24l";
-    private static final String CLIENT_SECRET = "g9ej0i1jf3y68wchb0ncm266";
+    private static final String GET_SMS_CODE_URL = "https://api.kurobbs.com/user/getSmsCode";
+    private static final String ANDROID_UA = "Mozilla/5.0 (Linux; Android 9; 23116PN5BC Build/PQ3A.190605.02201427; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/124.0.6367.82 Mobile Safari/537.36 Kuro/2.5.0 KuroGameBox/2.5.0";
 
-    private String deviceId;
-    private String phone;
-    public SendSmsTask(String phone) {
+    private final String phone;
+    private final String geeTestData;
+
+    /**
+     * @param phone       手机号
+     * @param geeTestData 极验验证通过后的 tokens（JSON 字符串，首次传空串）
+     */
+    public SendSmsTask(String phone, String geeTestData) {
         this.phone = phone;
+        this.geeTestData = geeTestData != null ? geeTestData : "";
     }
+
+    public SendSmsTask(String phone) {
+        this(phone, "");
+    }
+
 
     @Override
-    protected ResponseBody<Boolean> call() throws Exception {
-        String response = needCaptcha();
-        LOG.debug(response);
-        int code = MAPPER.readTree(response).path("code").asInt();
-        String msg = MAPPER.readTree(response).path("msg").asText();
-        if (code == 0){
-            return ResponseBody.create(200,msg,true);
-        }else if (code == 41000){
-            return ResponseBody.create(41000,msg,true);
-        }else{
-            return ResponseBody.create(-1,msg,true);
-        }
-    }
+    protected ResponseBody<SmsCodeResponse> call() {
+        String devCode = getDevCode();
+        String distinctId = UUID.randomUUID().toString().replace("-", "");
+        String ip = getPublicIP();
 
-
-
-
-    private String needCaptcha() {
-        deviceId = UUIDHelper.generateDeviceId();
-        Map<String, String> params = getBaseKuroParams();
-        params.putAll(Map.of(
-                "response_type", RESPONSE_TYPE,
-                "phone", phone,
-                "pkg", PKG,
-                "client_id", CLIENT_ID,
-                "client_secret", CLIENT_SECRET
-        ));
+        // 构建 form body
+        String body = buildFormBody(devCode, distinctId, ip);
 
         try {
-            String response = postKuro(GET_SMS_CODE_URL, buildFormBody(params));
-            return response;
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(GET_SMS_CODE_URL))
+                    .timeout(Duration.ofSeconds(10))
+                    .header("User-Agent", ANDROID_UA)
+                    .header("Accept", "application/json, text/plain, */*")
+                    .header("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8")
+                    .header("source", "android")
+                    .header("devcode", devCode)
+                    .header("distinct_id", distinctId)
+                    .header("countrycode", "CN")
+                    .header("ip", ip)
+                    .header("model", "23116PN5BC")
+                    .header("lang", "zh-Hans")
+                    .header("version", "2.5.0")
+                    .header("versioncode", "2500")
+                    .POST(HttpRequest.BodyPublishers.ofString(body))
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            return parseResponse(response.body());
+
+        } catch (IOException | InterruptedException e) {
+            LOG.error("发送验证码请求失败", e);
+            return new ResponseBody<>(-1, "网络请求失败: " + e.getMessage());
         }
     }
 
-    /** 将参数 Map 编码为 application/x-www-form-urlencoded 格式 */
-    private String buildFormBody(Map<String, String> params) {
-        return params.entrySet().stream()
-                .map(entry -> urlEncode(entry.getKey()) + "=" + urlEncode(entry.getValue()))
-                .collect(Collectors.joining("&"));
+
+    /**
+     * 构建 application/x-www-form-urlencoded 请求体
+     */
+    private String buildFormBody(String devCode, String distinctId, String ip) {
+        StringBuilder sb = new StringBuilder();
+        appendParam(sb, "mobile", phone);
+        appendParam(sb, "devCode", devCode);
+        appendParam(sb, "distinct_id", distinctId);
+        appendParam(sb, "countryCode", "CN");
+        appendParam(sb, "ip", ip);
+        appendParam(sb, "model", "23116PN5BC");
+        appendParam(sb, "source", "android");
+        appendParam(sb, "geeTestData", geeTestData);
+        return sb.toString();
     }
 
-    /** URL 编码辅助方法 */
-    private String urlEncode(String value) {
-        return URLEncoder.encode(value != null ? value : "", StandardCharsets.UTF_8);
-    }
-
-    private String postKuro(String url, String body) throws IOException, InterruptedException {
-        HttpRequest request = commonBuilder(url)
-                .header("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8")
-                .header("kr-ver", "1.9.0")
-                .header("sec-fetch-dest", "empty")
-                .header("sec-fetch-mode", "cors")
-                .header("Origin", ORIGIN)
-                .POST(HttpRequest.BodyPublishers.ofString(body))
-                .build();
-        return CLIENT.send(request, HttpResponse.BodyHandlers.ofString()).body();
-    }
-
-    /** 构建通用 HTTP 请求头（UA、Referer、sec-ch-ua 等） */
-    private HttpRequest.Builder commonBuilder(String url) {
-        return HttpRequest.newBuilder()
-                .uri(URI.create(url))
-                .header("Accept", "*/*")
-                .header("Accept-Language", "zh-CN,zh;q=0.9")
-                .header("sec-ch-ua", SEC_CH_UA)
-                .header("sec-ch-ua-mobile", "?0")
-                .header("sec-ch-ua-platform", "\"Windows\"")
-                .header("sec-fetch-site", "cross-site")
-                .header("Referer", REFERER)
-                .header("User-Agent", USER_AGENT);
+    private void appendParam(StringBuilder sb, String key, String value) {
+        if (!sb.isEmpty()) {
+            sb.append('&');
+        }
+        sb.append(URLEncoder.encode(key, StandardCharsets.UTF_8));
+        sb.append('=');
+        sb.append(URLEncoder.encode(value != null ? value : "", StandardCharsets.UTF_8));
     }
 
 
-    /** 构建 Kuro API 请求的公共参数 */
-    private Map<String, String> getBaseKuroParams() {
-        return new HashMap<>(Map.of(
-                "redirect_uri", REDIRECT_URI,
-                "__e__", E_PARAM,
-                "pack_mark", PACK_MARK,
-                "projectId", PROJECT_ID,
-                "productId", PRODUCT_ID,
-                "platform", PLATFORM,
-                "channelId", CHANNEL_ID,
-                "deviceNum", deviceId,
-                "version", VERSION,
-                "sdkVersion", SDK_VERSION
-        ));
+    /**
+     * 解析 API 响应，提取 geeTest 状态
+     * <ul>
+     *   <li>code=200, geeTest=false → 验证码发送成功，返回 {@code ResponseBody(200, ...)}</li>
+     *   <li>code=200, geeTest=true  → 需要极验，返回 {@code ResponseBody(41000, ...)}，data 含 gt/challenge</li>
+     *   <li>code=242              → 发送过于频繁</li>
+     *   <li>其他                  → 透传 API 错误</li>
+     * </ul>
+     */
+    private ResponseBody<SmsCodeResponse> parseResponse(String responseBody) {
+        try {
+            ObjectMapper mapper = AppInjector.getInstance(ObjectMapper.class);
+            JsonNode root = mapper.readTree(responseBody);
+            int code = root.path("code").asInt();
+            String msg = root.path("msg").asText();
+
+            if (code != 200) {
+                LOG.warn("getSmsCode 返回非 200: code={}, msg={}", code, msg);
+                return new ResponseBody<>(code, msg);
+            }
+
+            JsonNode dataNode = root.path("data");
+            SmsCodeResponse smsData = mapper.treeToValue(dataNode, SmsCodeResponse.class);
+
+            if (smsData != null && smsData.isGeeTest()) {
+                // 需要极验人机验证
+                LOG.info("getSmsCode 需要极验: gt={}, challenge={}", smsData.getGt(), smsData.getChallenge());
+                return ResponseBody.create(41000, "需要完成人机验证", smsData);
+            }
+
+            // 验证码发送成功
+            return ResponseBody.create(200, msg, smsData);
+
+        } catch (Exception e) {
+            LOG.error("解析 getSmsCode 响应失败", e);
+            return new ResponseBody<>(-1, "解析响应失败: " + e.getMessage());
+        }
     }
-
-
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -5,6 +5,7 @@ open module cn.tealc.wutheringwavestool {
     requires javafx.graphics;
     requires javafx.media;
     requires javafx.swing;
+    requires javafx.web;
     requires org.kordamp.ikonli.core;
     requires org.kordamp.ikonli.material2;
     requires org.kordamp.ikonli.javafx;

--- a/src/main/resources/cn/tealc/wutheringwavestool/ui/geetest.html
+++ b/src/main/resources/cn/tealc/wutheringwavestool/ui/geetest.html
@@ -8,34 +8,387 @@
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; display: flex; justify-content: center; align-items: center; min-height: 100vh; background: #f5f5f5; }
 .container { text-align: center; padding: 20px; }
-.hint { color: #666; font-size: 14px; margin-bottom: 20px; }
 #captcha { display: inline-block; }
+
+#status-overlay {
+    position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    background: rgba(255,255,255,0.95); z-index: 9999;
+    transition: opacity 0.3s;
+}
+#status-overlay.hidden { display: none; }
+.spinner {
+    width: 36px; height: 36px;
+    border: 3px solid #e0e0e0; border-top-color: #1677ff;
+    border-radius: 50%; animation: spin 0.8s linear infinite;
+    margin-bottom: 16px;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+#status-text { color: #333; font-size: 14px; margin-bottom: 20px; }
+#fallback-btn {
+    padding: 8px 24px; background: #1677ff; color: #fff;
+    border: none; border-radius: 4px; font-size: 14px; cursor: pointer; display: none;
+}
+#fallback-btn:hover { background: #4096ff; }
 </style>
 </head>
 <body>
 <div class="container">
-  <div class="hint">请完成安全验证</div>
-  <div id="captcha"></div>
+    <div id="captcha"></div>
 </div>
+
+<div id="status-overlay">
+    <div class="spinner"></div>
+    <div id="status-text">正在尝试自动验证...</div>
+    <button id="fallback-btn" onclick="switchToManual()">切换至手动验证</button>
+</div>
+
 <script src="https://static.geetest.com/static/js/gt.js"></script>
 <script>
 var gt = '${gt}';
 var challenge = '${challenge}';
+var AUTO_SOLVE_TIMEOUT = 20000;
+var captchaObj = null;
+var autoTimer = null;
 
-initGeetest({
-    gt: gt,
-    challenge: challenge,
-    offline: false,
-    new_captcha: false,
-    product: 'popup',
-    width: '300px'
-}, function(captchaObj) {
-    captchaObj.appendTo('#captcha');
-    captchaObj.onSuccess(function() {
-        var result = captchaObj.getValidate();
-        window.bridge.onCaptchaSolved(JSON.stringify(result));
+/* =========================================================
+ * 初始化 Geetest SDK
+ * ========================================================= */
+function init() {
+    initGeetest({
+        gt: gt,
+        challenge: challenge,
+        offline: false,
+        new_captcha: false,
+        product: 'popup',
+        width: '300px'
+    }, function(captcha) {
+        captchaObj = captcha;
+        captchaObj.appendTo('#captcha');
+
+        captchaObj.onSuccess(function() {
+            var result = captchaObj.getValidate();
+            if (window.bridge) {
+                window.bridge.onCaptchaSolved(JSON.stringify(result));
+            }
+        });
+
+        // 等待渲染完毕后触发自动验证
+        setTimeout(startAutoSolve, 600);
     });
-});
+}
+
+/* =========================================================
+ * 触发并等待验证码弹窗
+ * ========================================================= */
+function startAutoSolve() {
+    showStatus('正在尝试自动验证...');
+
+    // 1) 尝试用 SDK 方法触发弹窗
+    if (captchaObj && typeof captchaObj.verify === 'function') {
+        captchaObj.verify();
+    } else {
+        // 2) DOM 点击回退：找到极验渲染的按钮
+        triggerPopupByDOM();
+    }
+
+    // 3) 轮询等待 canvas 元素出现（验证码弹窗已渲染完毕）
+    var pollCount = 0;
+    var pollTimer = setInterval(function() {
+        pollCount++;
+        var bg = document.querySelector('.geetest_canvas_bg');
+        if (bg && bg.width > 0) {
+            clearInterval(pollTimer);
+            clearTimeout(autoTimer);
+            setTimeout(autoSolve, 500);
+        }
+        if (pollCount > 60) {
+            clearInterval(pollTimer);
+            clearTimeout(autoTimer);
+            showFallback();
+        }
+    }, 200);
+
+    autoTimer = setTimeout(function() {
+        clearInterval(pollTimer);
+        showFallback();
+    }, AUTO_SOLVE_TIMEOUT);
+}
+
+function triggerPopupByDOM() {
+    var selectors = [
+        '.geetest_btn', '.geetest_radar_btn', '.geetest_icon',
+        '.geetest_click', '.geetest-btn', '.gt_ajax_tip'
+    ];
+    for (var i = 0; i < selectors.length; i++) {
+        var el = document.querySelector(selectors[i]);
+        if (el) { el.click(); return true; }
+    }
+    // 兜底：点击容器本身
+    var area = document.querySelector('#captcha > div');
+    if (area) { area.click(); return true; }
+    return false;
+}
+
+/* =========================================================
+ * 自动过码核心
+ * ========================================================= */
+function autoSolve() {
+    showStatus('正在识别滑块缺口...');
+
+    try {
+        var distance = -1;
+
+        // 方法一：全图 vs 缺图 像素对比
+        distance = findGapByDiff();
+
+        // 方法二：滑块图模板匹配（方法一失败时）
+        if (distance <= 0) {
+            showStatus('正在进行模板匹配...');
+            distance = findGapByMatch();
+        }
+
+        if (distance <= 0) {
+            showStatus('未识别到缺口位置');
+            showFallback();
+            return;
+        }
+
+        // 减去滑块按钮宽度的一半（偏移修正）
+        var offset = distance - 5;
+        if (offset < 0) offset = 0;
+
+        var slider = document.querySelector('.gt_slider_knob, .geetest_slider_button');
+        if (!slider) {
+            showFallback();
+            return;
+        }
+
+        showStatus('正在进行人机验证...');
+
+        // 生成类人轨迹并拖拽
+        var track = generateTrack(offset);
+        simulateDrag(slider, track, offset);
+
+    } catch (e) {
+        console.log('Auto-solve error:', e);
+        showFallback();
+    }
+}
+
+/* ---------------------------------------------------------
+ * 方法一：全图 vs 缺图 像素逐列对比
+ * --------------------------------------------------------- */
+function findGapByDiff() {
+    var fullbg = document.querySelector('.geetest_canvas_fullbg');
+    var bg = document.querySelector('.geetest_canvas_bg');
+    if (!fullbg || !bg || fullbg.width === 0) return -1;
+
+    try {
+        var ctx1 = fullbg.getContext('2d');
+        var ctx2 = bg.getContext('2d');
+        var w = fullbg.width, h = fullbg.height;
+
+        var d1 = ctx1.getImageData(0, 0, w, h).data;
+        var d2 = ctx2.getImageData(0, 0, w, h).data;
+
+        var gapStart = -1, inGap = false, gapWidth = 0;
+
+        for (var x = 0; x < w; x++) {
+            var diffPixels = 0;
+            for (var y = 0; y < h; y++) {
+                var i = (y * w + x) * 4;
+                var diff = Math.abs(d1[i] - d2[i]) +
+                           Math.abs(d1[i+1] - d2[i+1]) +
+                           Math.abs(d1[i+2] - d2[i+2]);
+                if (diff > 40) diffPixels++;
+            }
+
+            var ratio = diffPixels / h;
+
+            if (ratio > 0.15 && !inGap) {
+                inGap = true;
+                gapStart = x;
+                gapWidth = 1;
+            } else if (ratio > 0.15 && inGap) {
+                gapWidth++;
+            } else if (ratio <= 0.15 && inGap) {
+                if (gapWidth > 5) return gapStart;
+                inGap = false;
+            }
+        }
+        if (inGap && gapStart > 0) return gapStart;
+    } catch (e) {
+        console.log('findGapByDiff error:', e);
+    }
+    return -1;
+}
+
+/* ---------------------------------------------------------
+ * 方法二：滑块图模板匹配（滑动窗口）
+ * --------------------------------------------------------- */
+function findGapByMatch() {
+    var slice = document.querySelector('.geetest_canvas_slice');
+    var bg = document.querySelector('.geetest_canvas_bg');
+    if (!slice || !bg || slice.width === 0) return -1;
+
+    try {
+        var ctxS = slice.getContext('2d');
+        var ctxB = bg.getContext('2d');
+        var sw = slice.width, sh = slice.height;
+        var bw = bg.width, bh = bg.height;
+
+        var sData = ctxS.getImageData(0, 0, sw, sh).data;
+        var bData = ctxB.getImageData(0, 0, bw, bh).data;
+
+        // 1) 找出滑块图非透明区域（实际拼图块）
+        var minX = sw, maxX = 0, minY = sh, maxY = 0;
+        for (var y = 0; y < sh; y++) {
+            for (var x = 0; x < sw; x++) {
+                if (sData[(y * sw + x) * 4 + 3] > 128) {
+                    if (x < minX) minX = x;
+                    if (x > maxX) maxX = x;
+                    if (y < minY) minY = y;
+                    if (y > maxY) maxY = y;
+                }
+            }
+        }
+
+        var pw = maxX - minX + 1;
+        var ph = maxY - minY + 1;
+        if (pw <= 0 || ph <= 0) return -1;
+
+        // 2) 在背景图上滑动匹配
+        var bestX = -1;
+        var bestScore = Infinity;
+        var searchEnd = bw - pw;
+        if (searchEnd <= 0) return -1;
+
+        for (var x = 0; x <= searchEnd; x++) {
+            var score = 0, count = 0;
+
+            for (var py = minY; py <= maxY; py++) {
+                for (var px = minX; px <= maxX; px++) {
+                    var si = (py * sw + px) * 4;
+                    if (sData[si + 3] < 128) continue;
+
+                    var bi = (py * bw + (x + px - minX)) * 4;
+                    var diff = Math.abs(sData[si] - bData[bi]) +
+                               Math.abs(sData[si+1] - bData[bi+1]) +
+                               Math.abs(sData[si+2] - bData[bi+2]);
+                    score += diff;
+                    count++;
+                }
+            }
+
+            if (count > 0) {
+                var avg = score / count;
+                if (avg < bestScore) {
+                    bestScore = avg;
+                    bestX = x;
+                }
+            }
+        }
+
+        return bestX;
+
+    } catch (e) {
+        console.log('findGapByMatch error:', e);
+    }
+    return -1;
+}
+
+/* =========================================================
+ * 生成类人拖拽轨迹（先加速后减速 + 随机抖动）
+ * ========================================================= */
+function generateTrack(distance) {
+    var track = [];
+    var current = 0;
+    var mid = distance * (0.6 + Math.random() * 0.2);
+    var t = 0;
+    var v = 0;
+
+    while (current < distance) {
+        if (current < mid) {
+            v += 0.5 + Math.random() * 2.5;
+        } else {
+            v -= 0.5 + Math.random() * 1.5;
+            if (v < 1) v = 1;
+        }
+        current += v;
+        if (current > distance) current = distance;
+        t += 5 + Math.random() * 20;
+
+        track.push({
+            x: Math.round(current * 100) / 100,
+            y: Math.round((Math.random() * 4 - 2) * 100) / 100,
+            t: t
+        });
+        if (current >= distance) break;
+    }
+    return track;
+}
+
+/* =========================================================
+ * 模拟鼠标拖拽
+ * ========================================================= */
+function simulateDrag(el, track, distance) {
+    var rect = el.getBoundingClientRect();
+    var startX = rect.left + rect.width / 2;
+    var startY = rect.top + rect.height / 2;
+
+    // mousedown
+    el.dispatchEvent(new MouseEvent('mousedown', {
+        clientX: startX, clientY: startY, bubbles: true, cancelable: true
+    }));
+
+    // 沿轨迹移动
+    for (var i = 0; i < track.length; i++) {
+        (function(index) {
+            setTimeout(function() {
+                el.dispatchEvent(new MouseEvent('mousemove', {
+                    clientX: startX + track[index].x,
+                    clientY: startY + track[index].y,
+                    bubbles: true, cancelable: true
+                }));
+            }, track[index].t);
+        })(i);
+    }
+
+    // mouseup 在终点
+    setTimeout(function() {
+        el.dispatchEvent(new MouseEvent('mouseup', {
+            clientX: startX + distance,
+            clientY: startY,
+            bubbles: true, cancelable: true
+        }));
+    }, track[track.length - 1].t + 50);
+}
+
+/* =========================================================
+ * UI 控制
+ * ========================================================= */
+function showStatus(text) {
+    document.getElementById('status-text').textContent = text;
+    document.getElementById('fallback-btn').style.display = 'none';
+    document.getElementById('status-overlay').classList.remove('hidden');
+}
+
+function showFallback() {
+    document.getElementById('status-text').textContent = '自动验证失败，请手动完成验证';
+    document.getElementById('fallback-btn').style.display = 'block';
+}
+
+function switchToManual() {
+    document.getElementById('status-overlay').classList.add('hidden');
+    // 重置验证码面板（部分极验版本需要重新初始化）
+    if (captchaObj && typeof captchaObj.reset === 'function') {
+        captchaObj.reset();
+    }
+}
+
+// 启动
+init();
 </script>
 </body>
 </html>

--- a/src/main/resources/cn/tealc/wutheringwavestool/ui/geetest.html
+++ b/src/main/resources/cn/tealc/wutheringwavestool/ui/geetest.html
@@ -47,9 +47,10 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-
 <script>
 var gt = '${gt}';
 var challenge = '${challenge}';
-var AUTO_SOLVE_TIMEOUT = 20000;
+var AUTO_SOLVE_TIMEOUT = 25000;
 var captchaObj = null;
 var autoTimer = null;
+var solvingInProgress = false;
 
 /* =========================================================
  * 初始化 Geetest SDK
@@ -82,35 +83,38 @@ function init() {
  * 触发并等待验证码弹窗
  * ========================================================= */
 function startAutoSolve() {
+    if (solvingInProgress) return;
+    solvingInProgress = true;
     showStatus('正在尝试自动验证...');
 
     // 1) 尝试用 SDK 方法触发弹窗
     if (captchaObj && typeof captchaObj.verify === 'function') {
         captchaObj.verify();
     } else {
-        // 2) DOM 点击回退：找到极验渲染的按钮
         triggerPopupByDOM();
     }
 
-    // 3) 轮询等待 canvas 元素出现（验证码弹窗已渲染完毕）
+    // 2) 轮询等待 canvas 元素出现（验证码弹窗已渲染完毕）
     var pollCount = 0;
     var pollTimer = setInterval(function() {
         pollCount++;
-        var bg = document.querySelector('.geetest_canvas_bg');
+        var bg = document.querySelector('canvas.geetest_canvas_bg, .geetest_canvas_bg canvas');
         if (bg && bg.width > 0) {
             clearInterval(pollTimer);
             clearTimeout(autoTimer);
-            setTimeout(autoSolve, 500);
+            setTimeout(captureAndDetect, 500);
         }
         if (pollCount > 60) {
             clearInterval(pollTimer);
             clearTimeout(autoTimer);
+            solvingInProgress = false;
             showFallback();
         }
     }, 200);
 
     autoTimer = setTimeout(function() {
         clearInterval(pollTimer);
+        solvingInProgress = false;
         showFallback();
     }, AUTO_SOLVE_TIMEOUT);
 }
@@ -124,178 +128,146 @@ function triggerPopupByDOM() {
         var el = document.querySelector(selectors[i]);
         if (el) { el.click(); return true; }
     }
-    // 兜底：点击容器本身
     var area = document.querySelector('#captcha > div');
     if (area) { area.click(); return true; }
     return false;
 }
 
 /* =========================================================
- * 自动过码核心
+ * 捕获 canvas 数据，发送到 Java 进行缺口检测
  * ========================================================= */
-function autoSolve() {
+function captureAndDetect() {
     showStatus('正在识别滑块缺口...');
 
     try {
-        var distance = -1;
-
-        // 方法一：全图 vs 缺图 像素对比
-        distance = findGapByDiff();
-
-        // 方法二：滑块图模板匹配（方法一失败时）
-        if (distance <= 0) {
-            showStatus('正在进行模板匹配...');
-            distance = findGapByMatch();
+        // 获取 bg canvas
+        var bgCanvas = document.querySelector('canvas.geetest_canvas_bg');
+        if (!bgCanvas || bgCanvas.width === 0) {
+            // 也可能是 div 包 canvas 的结构
+            bgCanvas = document.querySelector('.geetest_canvas_bg canvas');
         }
+        var bgData = bgCanvas ? bgCanvas.toDataURL('image/png') : null;
 
-        if (distance <= 0) {
-            showStatus('未识别到缺口位置');
-            showFallback();
+        // 获取 slice canvas
+        var sliceCanvas = document.querySelector('canvas.geetest_canvas_slice');
+        if (!sliceCanvas || sliceCanvas.width === 0) {
+            sliceCanvas = document.querySelector('.geetest_canvas_slice canvas');
+        }
+        var sliceData = sliceCanvas ? sliceCanvas.toDataURL('image/png') : null;
+
+        if (!bgData || !sliceData) {
+            console.log('Canvas not available, trying fallback');
+            // 尝试 CSS background-image 方案
+            captureFromCSS();
             return;
         }
 
-        // 减去滑块按钮宽度的一半（偏移修正）
-        var offset = distance - 5;
-        if (offset < 0) offset = 0;
-
-        var slider = document.querySelector('.gt_slider_knob, .geetest_slider_button');
-        if (!slider) {
+        // 发送到 Java 侧检测缺口
+        if (window.bridge) {
+            window.bridge.detectGap(bgData, sliceData);
+        } else {
             showFallback();
-            return;
         }
-
-        showStatus('正在进行人机验证...');
-
-        // 生成类人轨迹并拖拽
-        var track = generateTrack(offset);
-        simulateDrag(slider, track, offset);
 
     } catch (e) {
-        console.log('Auto-solve error:', e);
+        console.log('captureAndDetect error:', e);
         showFallback();
     }
 }
 
-/* ---------------------------------------------------------
- * 方法一：全图 vs 缺图 像素逐列对比
- * --------------------------------------------------------- */
-function findGapByDiff() {
-    var fullbg = document.querySelector('.geetest_canvas_fullbg');
-    var bg = document.querySelector('.geetest_canvas_bg');
-    if (!fullbg || !bg || fullbg.width === 0) return -1;
+/**
+ * 从 CSS background-image 捕获图像（某些极验版本用 CSS 而非 canvas）
+ */
+function captureFromCSS() {
+    showStatus('正在尝试备用识别方案...');
 
     try {
-        var ctx1 = fullbg.getContext('2d');
-        var ctx2 = bg.getContext('2d');
-        var w = fullbg.width, h = fullbg.height;
+        var bgEl = document.querySelector('.geetest_canvas_bg');
+        var sliceEl = document.querySelector('.geetest_canvas_slice');
+        if (!bgEl || !sliceEl) { showFallback(); return; }
 
-        var d1 = ctx1.getImageData(0, 0, w, h).data;
-        var d2 = ctx2.getImageData(0, 0, w, h).data;
+        var bgStyle = getComputedStyle(bgEl).backgroundImage;
+        var sliceStyle = getComputedStyle(sliceEl).backgroundImage;
 
-        var gapStart = -1, inGap = false, gapWidth = 0;
+        var bgUrl = extractUrl(bgStyle);
+        var sliceUrl = extractUrl(sliceStyle);
 
-        for (var x = 0; x < w; x++) {
-            var diffPixels = 0;
-            for (var y = 0; y < h; y++) {
-                var i = (y * w + x) * 4;
-                var diff = Math.abs(d1[i] - d2[i]) +
-                           Math.abs(d1[i+1] - d2[i+1]) +
-                           Math.abs(d1[i+2] - d2[i+2]);
-                if (diff > 40) diffPixels++;
-            }
-
-            var ratio = diffPixels / h;
-
-            if (ratio > 0.15 && !inGap) {
-                inGap = true;
-                gapStart = x;
-                gapWidth = 1;
-            } else if (ratio > 0.15 && inGap) {
-                gapWidth++;
-            } else if (ratio <= 0.15 && inGap) {
-                if (gapWidth > 5) return gapStart;
-                inGap = false;
-            }
+        if (bgUrl && sliceUrl) {
+            // 把 URL 图像绘制到临时 canvas 再导出
+            loadImageAsBase64(bgUrl, function(bgBase64) {
+                loadImageAsBase64(sliceUrl, function(sliceBase64) {
+                    if (window.bridge) {
+                        window.bridge.detectGap(bgBase64, sliceBase64);
+                    } else {
+                        showFallback();
+                    }
+                });
+            });
+        } else {
+            showFallback();
         }
-        if (inGap && gapStart > 0) return gapStart;
     } catch (e) {
-        console.log('findGapByDiff error:', e);
+        console.log('captureFromCSS error:', e);
+        showFallback();
     }
-    return -1;
 }
 
-/* ---------------------------------------------------------
- * 方法二：滑块图模板匹配（滑动窗口）
- * --------------------------------------------------------- */
-function findGapByMatch() {
-    var slice = document.querySelector('.geetest_canvas_slice');
-    var bg = document.querySelector('.geetest_canvas_bg');
-    if (!slice || !bg || slice.width === 0) return -1;
+function extractUrl(cssValue) {
+    var m = cssValue.match(/url\(['"]?([^'")]+)['"]?\)/);
+    return m ? m[1] : null;
+}
 
-    try {
-        var ctxS = slice.getContext('2d');
-        var ctxB = bg.getContext('2d');
-        var sw = slice.width, sh = slice.height;
-        var bw = bg.width, bh = bg.height;
+function loadImageAsBase64(url, callback) {
+    var img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = function() {
+        var c = document.createElement('canvas');
+        c.width = img.naturalWidth;
+        c.height = img.naturalHeight;
+        var ctx = c.getContext('2d');
+        ctx.drawImage(img, 0, 0);
+        callback(c.toDataURL('image/png'));
+    };
+    img.onerror = function() { callback(null); };
+    img.src = url;
+}
 
-        var sData = ctxS.getImageData(0, 0, sw, sh).data;
-        var bData = ctxB.getImageData(0, 0, bw, bh).data;
-
-        // 1) 找出滑块图非透明区域（实际拼图块）
-        var minX = sw, maxX = 0, minY = sh, maxY = 0;
-        for (var y = 0; y < sh; y++) {
-            for (var x = 0; x < sw; x++) {
-                if (sData[(y * sw + x) * 4 + 3] > 128) {
-                    if (x < minX) minX = x;
-                    if (x > maxX) maxX = x;
-                    if (y < minY) minY = y;
-                    if (y > maxY) maxY = y;
-                }
-            }
-        }
-
-        var pw = maxX - minX + 1;
-        var ph = maxY - minY + 1;
-        if (pw <= 0 || ph <= 0) return -1;
-
-        // 2) 在背景图上滑动匹配
-        var bestX = -1;
-        var bestScore = Infinity;
-        var searchEnd = bw - pw;
-        if (searchEnd <= 0) return -1;
-
-        for (var x = 0; x <= searchEnd; x++) {
-            var score = 0, count = 0;
-
-            for (var py = minY; py <= maxY; py++) {
-                for (var px = minX; px <= maxX; px++) {
-                    var si = (py * sw + px) * 4;
-                    if (sData[si + 3] < 128) continue;
-
-                    var bi = (py * bw + (x + px - minX)) * 4;
-                    var diff = Math.abs(sData[si] - bData[bi]) +
-                               Math.abs(sData[si+1] - bData[bi+1]) +
-                               Math.abs(sData[si+2] - bData[bi+2]);
-                    score += diff;
-                    count++;
-                }
-            }
-
-            if (count > 0) {
-                var avg = score / count;
-                if (avg < bestScore) {
-                    bestScore = avg;
-                    bestX = x;
-                }
-            }
-        }
-
-        return bestX;
-
-    } catch (e) {
-        console.log('findGapByMatch error:', e);
+/* =========================================================
+ * Java 侧缺口检测完成后的回调
+ * ========================================================= */
+window.onGapDetected = function(gapX) {
+    if (gapX > 0) {
+        showStatus('正在进行人机验证...');
+        doDrag(gapX);
+    } else {
+        showStatus('未识别到缺口位置');
+        solvingInProgress = false;
+        showFallback();
     }
-    return -1;
+};
+
+/* =========================================================
+ * 执行拖拽
+ * ========================================================= */
+function doDrag(distance) {
+    if (distance <= 0) {
+        showFallback();
+        return;
+    }
+
+    // 减去滑块按钮宽度的一半（偏移修正）
+    var offset = distance - 5;
+    if (offset < 0) offset = 0;
+
+    var slider = document.querySelector('.gt_slider_knob, .geetest_slider_button');
+    if (!slider) {
+        showFallback();
+        return;
+    }
+
+    // 生成类人轨迹并拖拽
+    var track = generateTrack(offset);
+    simulateDrag(slider, track, offset);
 }
 
 /* =========================================================
@@ -375,13 +347,14 @@ function showStatus(text) {
 }
 
 function showFallback() {
+    solvingInProgress = false;
     document.getElementById('status-text').textContent = '自动验证失败，请手动完成验证';
     document.getElementById('fallback-btn').style.display = 'block';
 }
 
 function switchToManual() {
+    solvingInProgress = false;
     document.getElementById('status-overlay').classList.add('hidden');
-    // 重置验证码面板（部分极验版本需要重新初始化）
     if (captchaObj && typeof captchaObj.reset === 'function') {
         captchaObj.reset();
     }

--- a/src/main/resources/cn/tealc/wutheringwavestool/ui/geetest.html
+++ b/src/main/resources/cn/tealc/wutheringwavestool/ui/geetest.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>极验验证</title>
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; display: flex; justify-content: center; align-items: center; min-height: 100vh; background: #f5f5f5; }
+.container { text-align: center; padding: 20px; }
+.hint { color: #666; font-size: 14px; margin-bottom: 20px; }
+#captcha { display: inline-block; }
+</style>
+</head>
+<body>
+<div class="container">
+  <div class="hint">请完成安全验证</div>
+  <div id="captcha"></div>
+</div>
+<script src="https://static.geetest.com/static/js/gt.js"></script>
+<script>
+var gt = '${gt}';
+var challenge = '${challenge}';
+
+initGeetest({
+    gt: gt,
+    challenge: challenge,
+    offline: false,
+    new_captcha: false,
+    product: 'popup',
+    width: '300px'
+}, function(captchaObj) {
+    captchaObj.appendTo('#captcha');
+    captchaObj.onSuccess(function() {
+        var result = captchaObj.getValidate();
+        window.bridge.onCaptchaSolved(JSON.stringify(result));
+    });
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 改动说明

将极验滑块验证码的缺口识别从 JS 侧的 Canvas 像素颜色比对，替换为 **Java 侧的 Sobel 边缘检测 + 模板匹配**，精度和抗干扰能力显著提升。

## 改了什么

### 新增：\GapDetector.java\
纯 Java 实现的缺口检测算法，零新依赖（复用项目中已有的 \java.desktop\/\javafx.swing\）：
1. 从 slice 图 alpha 通道提取拼图块包围盒
2. Sobel 3×3 算子边缘检测（拼图块 + 背景图）
3. 清零拼图块起始区域的边缘（防自匹配）
4. SAD（绝对差之和）滑动窗口模板匹配
5. 偏移修正算出实际拖拽距离

### 修改：\GeetestCaptchaDialog.java\
- 新增 \CaptchaBridge.detectGap(bgBase64, sliceBase64)\
- 异步处理：后台线程运行 GapDetector，完成后回调 JS

### 修改：\geetest.html\
- 删除低精度的 \indGapByDiff()\ 和 \indGapByMatch()\（JS 像素比对）
- 新增 \captureAndDetect()\ 捕获 canvas 数据发送到 Java
- 新增 CSS background-image 备用捕获方案
- \window.onGapDetected\ 接收 Java 检测结果，JS 仅负责轨迹生成 + 拖拽

## 对比

| 方案 | 方法 | 精度 |
|------|------|------|
| 旧（JS） | Canvas pixel color diff + template match | 低（易受颜色/光照干扰） |
| 新（Java） | Sobel 边缘检测 + SAD 模板匹配 | 高（结构边缘，抗干扰） |

> 注：Maven 编译因 \mvvmfx:1.9.0-SNAPSHOT\ 不可达阻塞（预存问题，与本 PR 无关）